### PR TITLE
scroll to automatically posted tweets

### DIFF
--- a/app/assets/javascripts/tweet.js
+++ b/app/assets/javascripts/tweet.js
@@ -29,12 +29,17 @@ $(function(){
       processData: false,
       contentType: false
     })
-    .done(function(tweet){
-      var html = buildHTML(tweet);
+    .done(function(tweets){
+      var html = buildHTML(tweets);
       console.log(html);
       $('.main-tweet__contents__content').append(html);
       $('.main-tweet__contents__messages--text').val('');
       $('.main-tweet__contents__messages--btn').prop('disabled', false);
+      $('.main-tweet__contents__content').animate({ scrollTop: $('.main-tweet__contents__content')[0].scrollHeight});
+      }
+    )
+    .fail(function(){
+      alert('error');
     })
-  })
+  });
 });


### PR DESCRIPTION
#What
自動的に、追加されたメッセージが読めるように機能を追加する。
- jQueryのanimate関数を利用
  - コードは非同期通信が成功した場合行う処理の最後。

#Why
今のアプリの動作では、メッセージの数が多い場合、
追加されたメッセージを読むために手動でスクロールする必要がある。
それを自動的に、追加分メッセージまでスクロールするようにするため。